### PR TITLE
Update Utils.php

### DIFF
--- a/modules/Import/helpers/Utils.php
+++ b/modules/Import/helpers/Utils.php
@@ -163,7 +163,7 @@ class Import_Utils_Helper
 			return false;
 		}
 		$fileInstance = \App\Fields\File::loadFromRequest($_FILES['import_file']);
-		if ($fileInstance->getEncoding() !== strtoupper($request->getByType('file_encoding', 'Text'))) {
+		if ($fileInstance->getExtension(true)!= "zip" && $fileInstance->getEncoding() !== strtoupper($request->getByType('file_encoding', 'Text'))) {
 			$request->set('error_message', \App\Language::translateArgs('LBL_IMPORT_FILE_DIFFERENT_ENCODING', 'Import', $fileInstance->getEncoding()));
 			return false;
 		}


### PR DESCRIPTION
## Description
In case of importing ZIP containing XML encoded in UTF8 YetiForce discovered it as a ISO encoded.
Added checking filetype and omitting encoding checking for ZIP files.
It's possible to unzip an archive and check XML files, but it will fail if for any reason the archive would contain files in more than one encoding standard.

## Testing
1. Export some records from Contacts.
2. Manually add them to archive in Windows Explorer.
3. Import records as a ZIP file.

## Changes
<!--- What kind of changes are included in your pull request? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Final checklist
<!--- Go over all the following points and check all the boxes that apply. --->
<!--- We require everyone who wants to contribute to our project to sign the Contributor License Agreement. If you haven’t, please send us an email to cla@yetiforce.com and we will send you the form. --->
- [X ] My code is written according to the guidelines found [here] (https://github.com/php-fig/fig-standards).
- [ ] I have signed the Contributor Licence Agreement between me and YetiForce.

<!--- Your pull request will be tested via Travis CI to automatically indicate that your changes do not prevent compilation. --->

<!--- If it reports back that there are problems, you can log into the Travis system and check the log report for your pull request to see what the problem was. --->

<!--- Please check on your pull request from time to time, in case we have questions or need some extra information. --->
